### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Customized from [Maple's Vim Config](https://github.com/humiaozuzu/dot-vimrc)
 2. Clone and install this repo:
 
         git clone https://github.com/jagandecapri/vimrc.git ~/.vim
-        ln -s ~/.vim/vimrc ~/.vimrc
+        ln -s ~/.vim/.vimrc ~/.vimrc
 
 3. Setup `Vundle`:
 


### PR DESCRIPTION
Missing " . " in front of vimrc
ln -s ~/.vim/vimrc ~/.vimrc => ln -s ~/.vim/.vimrc ~/.vimrc
